### PR TITLE
Fix compilation

### DIFF
--- a/etc/build/build.xml
+++ b/etc/build/build.xml
@@ -80,7 +80,7 @@
 				<file name="Sidebar-Advanced.js" />
 				<file name="Sidebar-Android.js" />
 				<file name="Sidebar-ArchiMate.js" />
-				<file name="Sidebar-ArchiMate3.js" />
+				<file name="Sidebar-Archimate3.js" />
 				<file name="Sidebar-Arrows2.js" />
 				<file name="Sidebar-AWS.js" />
 				<file name="Sidebar-AWS3D.js" />


### PR DESCRIPTION
Fix wrong js filename in build.xml. It fails on case-sensitive filesystems otherwise.