### PR TITLE
added build instructions to the developing section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A development guide is being started on the Github project wiki. There is a [dra
 
 The [mxGraph documentation](https://jgraph.github.io/mxgraph/) provides a lot of the docs for the bottom part of the stack. There is an [mxgraph tag on SO](http://stackoverflow.com/questions/tagged/mxgraph).
 
+If you want to build *draw.io*, run [`ant`](https://en.wikipedia.org/wiki/Apache_Ant) in the repo’s `/etc/build` folder. 
+
 Running
 -------
 The simplest way to run draw.io initially is to fork this project, [publish the master branch to Github pages](https://help.github.com/categories/github-pages-basics/) and the [pages sites](https://jgraph.github.io/draw.io/war/index.html) will have the full editor functionality (sans the integrations).


### PR DESCRIPTION
I added build instructions to the developing section of README.md .

The last paragraph is untouched by me; the »change« seems to come by saving it.