### PR TITLE
Sandstorm: Properly support gzipped assets.

### DIFF
--- a/etc/sandstorm/stage.sh
+++ b/etc/sandstorm/stage.sh
@@ -40,6 +40,10 @@ mkdir -p build/.sandstorm/client/styles
 cp -rf ../../war/styles/* build/.sandstorm/client/styles/
 mkdir -p build/.sandstorm/client/templates
 cp -rf ../../war/templates/* build/.sandstorm/client/templates/
+
+echo "Compressing assets"
+gfind build/.sandstorm/client -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.txt' -o -name '*.xml' | xargs gzip -k
+
 echo "Creating file list"
 cd build/.sandstorm
 gfind ./client -type f -printf "%p\n" | cut -c 3- >  sandstorm-files.list


### PR DESCRIPTION
This reverts my previous approach and applies a better approach.

My previous approach expected URLs to change to have ".gz" extensions. The new approach keeps the URLs the same but checks if a file exists on-disk that has the same name with the ".gz" extension.

Fixes https://github.com/sandstorm-io/sandstorm/issues/2641